### PR TITLE
feat: mysql image builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,7 @@ COPY mariadb-image-builder /usr/local/bin/mariadb-image-builder
 WORKDIR /builder
 
 COPY builder/mariadb.Dockerfile /builder/mariadb.Dockerfile
+COPY builder/mysql.Dockerfile /builder/mysql.Dockerfile
 COPY builder/my.cnf.tpl /builder/my.cnf.tpl
 COPY builder/import.my.cnf.tpl /builder/import.my.cnf.tpl
 

--- a/builder/my.cnf.tpl
+++ b/builder/my.cnf.tpl
@@ -5,7 +5,7 @@ user=root
 password=Lag00n
 
 [mysql]
-database=${BUILDER_BACKUP_IMAGE_DATABASE_NAME:-drupal}
+database=${BUILDER_BACKUP_IMAGE_DATABASE_NAME}
 
 [mysqld]
 max_allowed_packet=1G

--- a/builder/mysql.Dockerfile
+++ b/builder/mysql.Dockerfile
@@ -7,11 +7,11 @@ FROM ${BUILDER_IMAGE} AS builder
 # That file does the DB initialization but also runs mysql daemon, by removing the last line it will only init
 RUN ["sed", "-i", "s/exec \"$@\"/echo \"not running $@\"/", "/usr/local/bin/docker-entrypoint.sh"]
 
-# set the lagoon mariadb-drupal defaults here
+# set the lagoon mysql defaults here
 ENV MYSQL_ROOT_PASSWORD=Lag00n
-ENV MARIADB_DATABASE=drupal \
-    MARIADB_USER=drupal \
-    MARIADB_PASSWORD=drupal
+ENV MYSQL_DATABASE=lagoon \
+    MYSQL_USER=lagoon \
+    MYSQL_PASSWORD=lagoon
 
 COPY sanitised-dump.sql /docker-entrypoint-initdb.d/
 
@@ -23,16 +23,15 @@ COPY sanitised-dump.sql /docker-entrypoint-initdb.d/
 # in the output
 RUN /usr/local/bin/docker-entrypoint.sh mysqld \
     --max-allowed-packet=1G \
-    --datadir /initialized-db \
-    --aria-log-dir-path /initialized-db | tail -n 3
+    --datadir /initialized-db | tail -n 3
 
 #  create the `.my.cnf` that the lagoon mariadb images use
 # apply the permissions in the builder image before transferring to the clean image
 # this brings the `.my.cnf` file with it so that the clean image will start correctly
 COPY my.cnf /initialized-db/.my.cnf
-RUN chown -R 100:root /initialized-db
+RUN chown -R 999:root /initialized-db
 COPY import.my.cnf /etc/mysql/my.cnf
-RUN chown -R 100:root /etc/mysql/my.cnf
+RUN chown -R 999:root /etc/mysql/my.cnf
 
 FROM ${CLEAN_IMAGE}
 

--- a/internal/builder/builder_test.go
+++ b/internal/builder/builder_test.go
@@ -45,12 +45,14 @@ func Test_generateValues(t *testing.T) {
 				FixedDockerComposeServiceName: "MARIADB",
 				SourceImageName:               "mariadb:10.6",
 				CleanImageName:                "uselagoon/mariadb-10.6-drupal:latest",
+				ResultImageDatabaseName:       "drupal",
 				ResultImageName:               "lagpro/lagenv",
 				DockerHost:                    "docker-host.lagoon-image-builder.svc",
 				PushTags:                      "both",
 				RegistryUsername:              "reguser",
 				RegistryPassword:              "regpass",
 				RegistryHost:                  "reghost",
+				DatabaseType:                  "mariadb",
 				MTK: MTK{
 					Host:     "dbhost",
 					Username: "dbuser",
@@ -84,12 +86,14 @@ func Test_generateValues(t *testing.T) {
 				FixedDockerComposeServiceName: "MARIADB",
 				SourceImageName:               "mariadb:10.6",
 				CleanImageName:                "uselagoon/mariadb-10.6-drupal:latest",
+				ResultImageDatabaseName:       "drupal",
 				ResultImageName:               "reghost/mariadb-data",
 				DockerHost:                    "docker-host.lagoon-image-builder.svc",
 				PushTags:                      "both",
 				RegistryUsername:              "reguser",
 				RegistryPassword:              "regpass",
 				RegistryHost:                  "reghost",
+				DatabaseType:                  "mariadb",
 				MTK: MTK{
 					Host:     "dbhost",
 					Username: "dbuser",
@@ -124,12 +128,14 @@ func Test_generateValues(t *testing.T) {
 				FixedDockerComposeServiceName: "MARIADB",
 				SourceImageName:               "mariadb:10.6",
 				CleanImageName:                "uselagoon/mariadb-10.6-drupal:latest",
+				ResultImageDatabaseName:       "drupal",
 				ResultImageName:               "reghost/mariadb-data",
 				DockerHost:                    "docker-host.lagoon-image-builder.svc",
 				PushTags:                      "both",
 				RegistryUsername:              "reguser",
 				RegistryPassword:              "regpass",
 				RegistryHost:                  "reghost",
+				DatabaseType:                  "mariadb",
 				MTK: MTK{
 					Host:     "dbrrhost1",
 					Username: "dbuser",
@@ -167,12 +173,14 @@ func Test_generateValues(t *testing.T) {
 				FixedDockerComposeServiceName: "MARIADB",
 				SourceImageName:               "mariadb:10.6",
 				CleanImageName:                "uselagoon/mariadb-10.6-drupal:latest",
+				ResultImageDatabaseName:       "drupal",
 				ResultImageName:               "reghost/mariadb-data",
 				DockerHost:                    "docker-host.lagoon-image-builder.svc",
 				PushTags:                      "both",
 				RegistryUsername:              "reguser",
 				RegistryPassword:              "regpass",
 				RegistryHost:                  "reghost",
+				DatabaseType:                  "mariadb",
 				MTK: MTK{
 					Host:     "dbhostcentral",
 					Username: "dbusercentral",
@@ -207,12 +215,14 @@ func Test_generateValues(t *testing.T) {
 				FixedDockerComposeServiceName: "MARIADB",
 				SourceImageName:               "mariadb:10.6",
 				CleanImageName:                "uselagoon/mariadb-10.6-drupal:latest",
+				ResultImageDatabaseName:       "drupal",
 				ResultImageName:               "reghost/mariadb-data",
 				DockerHost:                    "docker-host.lagoon-image-builder.svc",
 				PushTags:                      "both",
 				RegistryUsername:              "reguser",
 				RegistryPassword:              "regpass",
 				RegistryHost:                  "reghost",
+				DatabaseType:                  "mariadb",
 				MTK: MTK{
 					Host:     "dbrrhost1",
 					Username: "mariadbuser",
@@ -246,6 +256,7 @@ func Test_generateValues(t *testing.T) {
 				FixedDockerComposeServiceName: "MARIADB",
 				SourceImageName:               "mariadb:10.6",
 				CleanImageName:                "uselagoon/mariadb-10.6-drupal:latest",
+				ResultImageDatabaseName:       "drupal",
 				ResultImageName:               "lagpro/lagenv",
 				DockerHost:                    "docker-host.lagoon-image-builder.svc",
 				PushTags:                      "both",
@@ -253,6 +264,48 @@ func Test_generateValues(t *testing.T) {
 				RegistryPassword:              "regpass",
 				RegistryHost:                  "reghost",
 				Debug:                         true,
+				DatabaseType:                  "mariadb",
+				MTK: MTK{
+					Host:     "dbhost",
+					Username: "dbuser",
+					Password: "dbpass",
+					Database: "dbname",
+				},
+			},
+		},
+		{
+			name:        "test7",
+			description: "same as test1 except mysql",
+			args: args{
+				envVars: []variables.LagoonEnvironmentVariable{
+					{Name: "BUILDER_BACKUP_IMAGE_TYPE", Value: "mysql", Scope: "global"},
+					{Name: "BUILDER_DOCKER_COMPOSE_SERVICE_NAME", Value: "mariadb", Scope: "global"},
+					{Name: "BUILDER_REGISTRY_USERNAME", Value: "reguser", Scope: "global"},
+					{Name: "BUILDER_REGISTRY_PASSWORD", Value: "regpass", Scope: "global"},
+					{Name: "BUILDER_REGISTRY_HOST", Value: "reghost", Scope: "global"},
+					{Name: "BUILDER_MTK_DUMP_HOSTNAME", Value: "dbhost", Scope: "global"},
+					{Name: "BUILDER_MTK_DUMP_USERNAME", Value: "dbuser", Scope: "global"},
+					{Name: "BUILDER_MTK_DUMP_PASSWORD", Value: "dbpass", Scope: "global"},
+					{Name: "BUILDER_MTK_DUMP_DATABASE", Value: "dbname", Scope: "global"},
+				},
+				setVars: []EnvironmentVariable{
+					{Name: "LAGOON_PROJECT", Value: "lagpro"},
+					{Name: "LAGOON_ENVIRONMENT", Value: "lagenv"},
+				},
+			},
+			want: Builder{
+				DockerComposeServiceName:      "mariadb",
+				FixedDockerComposeServiceName: "MARIADB",
+				SourceImageName:               "mysql:8.0.41-oracle",
+				CleanImageName:                "uselagoon/mysql-8.0:latest",
+				ResultImageDatabaseName:       "lagoon",
+				ResultImageName:               "lagpro/lagenv",
+				DockerHost:                    "docker-host.lagoon-image-builder.svc",
+				PushTags:                      "both",
+				RegistryUsername:              "reguser",
+				RegistryPassword:              "regpass",
+				RegistryHost:                  "reghost",
+				DatabaseType:                  "mysql",
 				MTK: MTK{
 					Host:     "dbhost",
 					Username: "dbuser",
@@ -299,10 +352,10 @@ func Test_imagePatternParser(t *testing.T) {
 		setVars []EnvironmentVariable
 	}
 	tests := []struct {
-		name string
+		name        string
 		description string
-		args args
-		want string
+		args        args
+		want        string
 	}{
 		{
 			name: "test1",
@@ -376,7 +429,7 @@ func Test_imagePatternParser(t *testing.T) {
 			want: "reghost/lagpro/mariadb-data",
 		},
 		{
-			name: "test4",
+			name:        "test4",
 			description: "Check whether $database works",
 			args: args{
 				pattern: "${organization}/database-mysql-${project}-${environment}-${database}",
@@ -393,7 +446,7 @@ func Test_imagePatternParser(t *testing.T) {
 					RegistryHost:                  "reghost",
 					RegistryOrganization:          "regorg",
 					MTK: MTK{
-						Database:		"test_database_name",
+						Database: "test_database_name",
 					},
 				},
 				setVars: []EnvironmentVariable{
@@ -404,7 +457,7 @@ func Test_imagePatternParser(t *testing.T) {
 			want: "regorg/database-mysql-lagpro-lagenv-test_database_name",
 		},
 		{
-			name: "test5",
+			name:        "test5",
 			description: "Check whether removal of double special characters works",
 			args: args{
 				pattern: "${organization}/database-mysql-${project}-${environment}-${database}",
@@ -421,7 +474,7 @@ func Test_imagePatternParser(t *testing.T) {
 					RegistryHost:                  "reghost",
 					RegistryOrganization:          "regorg",
 					MTK: MTK{
-						Database:		"test_database__name!!",
+						Database: "test_database__name!!",
 					},
 				},
 				setVars: []EnvironmentVariable{

--- a/mariadb-image-builder
+++ b/mariadb-image-builder
@@ -9,6 +9,11 @@ echo "=== Phase 1: variable setup ==="
 
 # source the variables required
 IMAGE_BUILD_DATA=$(database-image-task dump)
+if [ "$(echo "$IMAGE_BUILD_DATA" | jq -rc '.databaseType')" == "mysql" ]; then
+	ln -s mysql.Dockerfile Dockerfile
+else
+	ln -s mariadb.Dockerfile Dockerfile
+fi
 
 DEBUG=$(echo "$IMAGE_BUILD_DATA" | jq -rc '.debug')
 
@@ -97,18 +102,17 @@ else
 fi
 done
 
-# BUILDER_IMAGE_NAME is the upstream mariadb as it has support for importing in a particular way
+# BUILDER_IMAGE_NAME is the upstream mariadb/mysql as it has support for importing in a particular way
 # CLEAN_IMAGE_NAME is the lagoon database image used to copy the imported database into
 # BACKUP_IMAGE_NAME is the resulting built image to be tagged and pushed (eg quay.io/myproject/image)
 # BACKUP_IMAGE_TAG is optional and will default to `backup-${date}`
-# these have to be the same base `mariadb` version to work (ie mariadb:10.6 as the builder, and uselagoon/mariadb-10.6-drupal:latest as the clean resulting image)
+# these have to be the same base `mariadb/mysql` version to work (ie mariadb:10.6 as the builder, and uselagoon/mariadb-10.6-drupal:latest as the clean resulting image)
 
 
 # build the image, but exit on error
 if [ "$DEBUG" == "true" ]; then
 	set -o xtrace
 fi
-ln -s mariadb.Dockerfile Dockerfile
 set -o errexit
 # template out the my.cnf file for the images
 envsubst < my.cnf.tpl > my.cnf


### PR DESCRIPTION
This adds support for building a mysql base image instead of mariadb.

The default will be mariadb still, but can be switched with setting the envvar `BUILDER_BACKUP_IMAGE_TYPE` to `mysql` (in either the project/environment, or the task definition as a default value

closes #27 