### PR TITLE
fix: omitempty extended insert rows

### DIFF
--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -29,9 +29,9 @@ type Builder struct {
 	DockerHost                    string `json:"dockerHost"`
 	PushTags                      string `json:"pushTags"`
 	MTKYAML                       string `json:"mtkYAML"`
-	ExtendedInsertRows            string `json:"extendedInsertRows"`
+	ExtendedInsertRows            string `json:"extendedInsertRows,omitempty"`
 	DatabaseType                  string `json:"databaseType"`
-	Debug                         bool   `json:"debug,omitemtpy"`
+	Debug                         bool   `json:"debug,omitempty"`
 	MTK                           MTK    `json:"mtk"`
 }
 

--- a/mariadb-image-builder
+++ b/mariadb-image-builder
@@ -94,7 +94,7 @@ if [ "$DEBUG" == "true" ]; then
 	set +o xtrace
 fi
 
-if [ -n "$(echo "$IMAGE_BUILD_DATA" | jq -c '.extendedInsertRows')" ]; then
+if [ "$(echo "$IMAGE_BUILD_DATA" | jq -c '.extendedInsertRows // false')" != "false" ]; then
 	export MTK_EXTENDED_INSERT_ROWS=$(echo "$IMAGE_BUILD_DATA" | jq -rc '.extendedInsertRows')
 fi
 mtk-dump dump "$MTK_DATABASE" > "$san_db_dump_filename"


### PR DESCRIPTION
Fixes an issue where an empty extended insert rows variable is returned, changes it to omitempty